### PR TITLE
Add Temporary Access Pass (TAP) functionality

### DIFF
--- a/temporaryAccessPass/CHANGELOG.md
+++ b/temporaryAccessPass/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog - temporaryAccessPass
+
+All notable changes in this folder are documented in this file.
+
+## [Unreleased] - 2026-05-27
+
+Compared with `main` (`git diff main...HEAD -- temporaryAccessPass`):
+
+- Added 5 files
+- 626 insertions
+
+### Added
+
+- `configuration.json`
+  - Added connector configuration fields for:
+    - `TenantID`
+    - `AppId`
+    - `AppCertificateBase64String`
+    - `AppCertificatePassword`
+    - `TemporaryAccesPassLifetime`
+
+- `enable.ps1`
+  - Added Enable action script for Temporary Access Pass issuance.
+  - Added certificate-based app authentication to Microsoft Graph.
+  - Added validation for `TemporaryAccesPassLifetime` as required positive integer.
+  - Added TAP creation via Graph endpoint:
+    - `/users/{id}/authentication/temporaryAccessPassMethods`
+  - Added `Data.temporaryAccessPass` output for notification usage.
+  - Added `Data.validUntil` output with Dutch formatting without seconds (`dd-MM-yyyy HH:mm`).
+  - Added dry-run behavior and structured audit logging.
+  - Added error normalization and HTTP error handling.
+
+- `fieldMapping.json`
+  - Added mapping for correlation fields:
+    - `id` (AccountReference)
+    - `employeeId` (Correlation key)
+  - Added notification output fields:
+    - `temporaryAccessPass` (`UsedInNotifications: true`)
+    - `validUntil` (`UsedInNotifications: true`)
+
+- `notification.mjml`
+  - Added minimal notification template based on the shared MJML template style.
+  - Included TAP-specific variables:
+    - `{{ Data.temporaryAccessPass }}`
+    - `{{ Data.validUntil }}`
+
+- `README.md`
+  - Added full documentation for Temporary Access Pass module.
+  - Added requirements, including license group assignment requirement.
+  - Added go-live warning for active sessions and rollout guidance.
+  - Added explicit notification variables section.
+  - Added minimal notification template reference.
+  - Fixed markup/lint issues and aligned section structure.
+
+### Notes
+
+- Scope is limited to the `temporaryAccessPass` folder.
+- This changelog reflects branch changes relative to `main`.

--- a/temporaryAccessPass/README.md
+++ b/temporaryAccessPass/README.md
@@ -1,0 +1,160 @@
+# Temporary Access Pass (TAP)
+
+> [!NOTE]
+> The Temporary Access Pass feature is an optional provisioning operation for HelloID targets. This module enables issuing temporary access passes for user accounts in Microsoft Entra ID.
+
+## Table of contents
+
+- [Temporary Access Pass (TAP)](#temporary-access-pass-tap)
+  - [Table of contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Supported features](#supported-features)
+  - [Getting started](#getting-started)
+    - [Requirements](#requirements)
+    - [Connection settings](#connection-settings)
+    - [Field mapping](#field-mapping)
+  - [Configuration](#configuration)
+  - [Remarks](#remarks)
+    - [Temporary Access Pass Lifecycle](#temporary-access-pass-lifecycle)
+    - [Go-live and active sessions](#go-live-and-active-sessions)
+    - [Script flow](#script-flow)
+  - [Notifications](#Notifications)
+    - [Minimal notification template](#minimal-notification-template)
+    - [Notification variables](#notification-variables)
+  - [Development resources](#development-resources)
+    - [GraphAPI documentation](#graphapi-documentation)
+
+## Introduction
+
+The _Temporary Access Pass_ module provides a mechanism to enable temporary authentication credentials for Microsoft Entra ID user accounts. This feature is particularly useful for:
+
+- Initial account provisioning where users need immediate access before permanent credentials are set up
+- Onboarding scenarios where passwordless authentication methods are being configured
+- Emergency access scenarios where traditional authentication methods are temporarily unavailable
+
+The Temporary Access Pass feature operates within the context of a provisioning flow, generating a time-limited credential that can be used for initial sign-in.
+
+## Supported features
+
+- **Temporary Access Pass**: Supported `Yes`, Action `Enable`, generates a temporary access credential for the user.
+- **Correlate only mode**: Supported `Yes`, no action, works with correlate-only provisioning flows.
+- **Configurable lifetime**: Supported `Yes`, no action, allows customization of TAP validity period.
+- **Single-use tokens**: Supported `Yes`, no action, supports one-time use credentials.
+
+## Getting started
+
+### Requirements
+
+To use the Temporary Access Pass feature, ensure that:
+
+1. **App Registration Permissions**: Your Azure App Registration must have the following API permission:
+   - `UserAuthenticationMethod.ReadWrite.All` - Required to create and manage temporary access passes
+
+2. **HelloID Configuration**: The standard HelloID connector configuration must be in place with:
+   - App Registration ID
+   - Tenant ID
+   - Certificate-based authentication
+
+3. **Target System**: Microsoft Entra ID environment with sufficient permissions
+
+4. **License assignment**: The user must already have the required Microsoft license assigned (for example through a license group) before issuing a Temporary Access Pass.
+
+### Connection settings
+
+The Temporary Access Pass configuration uses the standard MS Entra connection settings:
+
+- **TenantID**: Azure AD Tenant ID (Directory ID). Required: `Yes`.
+- **AppId**: Application (Client) ID from App Registration. Required: `Yes`.
+- **AppCertificateBase64String**: Base64-encoded certificate for authentication. Required: `Yes`.
+- **AppCertificatePassword**: Password for the certificate. Required: `Yes`.
+- **TemporaryAccessPassLifetime**: Lifetime of the TAP in minutes (e.g., `43200` = 30 days). Required: `Yes`.
+
+For details on setting up certificate-based authentication, refer to the main connector README and Microsoft's official documentation:
+
+- [App-only authentication with certificate](https://learn.microsoft.com/en-us/graph/auth-limit-mailbox-access)
+
+### Field mapping
+
+The Temporary Access Pass mapping includes the following fields:
+
+- **id**: Unique identifier for the user (AccountReference). Type: `Text`. Used in: `Create`.
+- **employeeId**: Employee identifier (Correlation Key). Type: `Text`. Used in: `Create`.
+- **temporaryAccessPass**: The generated TAP credential. Type: `Text`. Used in: `Enable`.
+
+## Configuration
+
+### Enabling Temporary Access Pass
+
+To enable TAP in your HelloID provisioning target:
+
+1. Select the **Temporary Access Pass** option from the available provisioning features
+2. Configure the **TemporaryAccessPassLifetime** parameter with the desired lifetime in minutes:
+   - Example: `43200` minutes = 30 days
+   - Example: `1440` minutes = 1 day
+
+3. Map the `temporaryAccessPass` field to your notification system or audit logs to capture the generated credentials
+
+> [!IMPORTANT]
+> Temporary Access Pass credentials should be communicated to users through secure channels only. Ensure that your HelloID notification system is configured to handle sensitive credential data appropriately.
+
+## Remarks
+
+### Temporary Access Pass Lifecycle
+
+- **Generation**: A TAP is generated when the Enable action is triggered during provisioning
+- **Validity**: The credential remains valid for the configured lifetime (default: 43200 minutes / 30 days)
+- **Single-Use**: By default, the TAP is configured as single-use, meaning it can only be used once for authentication
+- **Retrieval**: The generated TAP value is returned in the `temporaryAccessPass` field and can be included in notifications
+
+> [!WARNING]
+> Once a Temporary Access Pass is generated, it cannot be retrieved from Microsoft Entra ID. The credential is only visible at generation time. Ensure that your provisioning workflow captures and securely distributes the credential to the user immediately.
+
+### Go-live and active sessions
+
+When a TAP is issued while a user is already signed in, some devices may prompt that user to sign in again with the Temporary Access Pass.
+
+For go-live scenarios, it is recommended to first assign account access entitlement without immediately issuing TAP, for example by:
+
+- running with `DryRun = $true`, or
+- executing account access import first via the account access import functionality.
+
+After access is in place and timing is controlled, issue the TAP.
+
+### Script flow
+
+The Temporary Access Pass Enable operation follows this process:
+
+1. **Authentication**: Establishes connection to Microsoft Graph API using certificate-based authentication
+2. **User Lookup**: Correlates the provisioning account to an existing Microsoft Entra ID user
+3. **Validation**: Verifies that the user account exists and is valid
+4. **TAP Creation**: Calls the Microsoft Graph API to create a new Temporary Access Pass for the user
+5. **Credential Return**: Returns the generated TAP credential in the provisioning context
+6. **Notification**: The TAP is made available for inclusion in provisioning notifications
+
+## Notifications
+
+### Minimal notification template
+
+A minimal MJML example is available in [temporaryAccessPass/notification.mjml](temporaryAccessPass/notification.mjml). Use this as a base template for customer-specific branding and wording.
+
+### Notification variables
+
+The following variables are available in notifications after TAP creation:
+
+- `Data.temporaryAccessPass`: the generated Temporary Access Pass value.
+- `Data.validUntil`: the TAP validity end date/time (Dutch format, without seconds).
+
+## Development resources
+
+### GraphAPI documentation
+
+The following Microsoft Graph API endpoint is used by the Temporary Access Pass feature:
+
+- Endpoint: `/users/{id}/authentication/temporaryAccessPassMethods`
+  Description: Create and manage TAP credentials
+  Method: `POST`
+
+For more information, refer to Microsoft's official documentation:
+
+- [Temporary Access Pass API Documentation](https://learn.microsoft.com/en-us/graph/api/resources/temporaryaccesspass?view=graph-rest-1.0)
+- [Create Temporary Access Pass](https://learn.microsoft.com/en-us/graph/api/authentication-post-temporaryaccesspassmethods?view=graph-rest-1.0&tabs=http)

--- a/temporaryAccessPass/configuration.json
+++ b/temporaryAccessPass/configuration.json
@@ -1,0 +1,56 @@
+[
+  {
+    "defaultValue": "",
+    "key": "TenantID",
+    "templateOptions": {
+      "description": "",
+      "label": "App Registration Directory (tenant) ID",
+      "placeholder": "00000000-0000-0000-0000-000000000000",
+      "required": true
+    },
+    "type": "input"
+  },
+  {
+    "defaultValue": "",
+    "key": "AppId",
+    "templateOptions": {
+      "description": "",
+      "label": "App Registration Application (client) ID",
+      "placeholder": "00000000-0000-0000-0000-000000000000",
+      "required": true
+    },
+    "type": "input"
+  },
+  {
+    "defaultValue": "",
+    "key": "AppCertificateBase64String",
+    "templateOptions": {
+      "label": "App Registration Certificate Base 64 String",
+      "placeholder": "WFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFg==",
+      "required": true,
+      "type": "password"
+    },
+    "type": "input"
+  },
+  {
+    "defaultValue": "",
+    "key": "AppCertificatePassword",
+    "templateOptions": {
+      "label": "App Registration Certificate Password",
+      "placeholder": "P@ssw0rd!",
+      "required": true,
+      "type": "password"
+    },
+    "type": "input"
+  },
+  {
+    "key": "TemporaryAccesPassLifetime",
+    "type": "input",
+    "defaultValue": "",
+    "templateOptions": {
+      "label": "Temporary Acces Pass Lifetime (m)",
+      "placeholder": "4320",
+      "required": true
+    }
+  }
+]

--- a/temporaryAccessPass/enable.ps1
+++ b/temporaryAccessPass/enable.ps1
@@ -1,0 +1,273 @@
+#################################################
+# HelloID-Conn-Prov-Target-Microsoft-Entra-ID-Enable
+# Correlate only + Temporary Access Pass
+# PowerShell V2
+#################################################
+
+# Enable TLS1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+
+#region functions
+function Resolve-MS-Entra-ExoError {
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory)]
+		[object]
+		$ErrorObject
+	)
+	process {
+		$httpErrorObj = [PSCustomObject]@{
+			ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
+			Line             = $ErrorObject.InvocationInfo.Line
+			ErrorDetails     = $ErrorObject.Exception.Message
+			FriendlyMessage  = $ErrorObject.Exception.Message
+		}
+
+		if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
+			$httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
+		}
+		elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+			if ($null -ne $ErrorObject.Exception.Response) {
+				$streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
+				if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
+					$httpErrorObj.ErrorDetails = $streamReaderResponse
+				}
+			}
+		}
+
+		try {
+			$errorDetailsObject = ($httpErrorObj.ErrorDetails | ConvertFrom-Json)
+			if ($errorDetailsObject.error_description) {
+				$httpErrorObj.FriendlyMessage = $errorDetailsObject.error_description
+			}
+			elseif ($errorDetailsObject.error.message) {
+				$httpErrorObj.FriendlyMessage = "$($errorDetailsObject.error.code): $($errorDetailsObject.error.message)"
+			}
+			elseif ($errorDetailsObject.error.details.message) {
+				$httpErrorObj.FriendlyMessage = "$($errorDetailsObject.error.details.code): $($errorDetailsObject.error.details.message)"
+			}
+			else {
+				$httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+			}
+		}
+		catch {
+			$httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+		}
+
+		Write-Output $httpErrorObj
+	}
+}
+
+function Get-MSEntraAccessToken {
+	[CmdletBinding()]
+	param(
+		[Parameter(Mandatory)]
+		$Certificate
+	)
+	try {
+		$derBytes = $Certificate.RawData
+
+		$sha256 = [System.Security.Cryptography.SHA256]::Create()
+		$hashBytes = $sha256.ComputeHash($derBytes)
+		$base64Thumbprint = [System.Convert]::ToBase64String($hashBytes).Replace('+', '-').Replace('/', '_').Replace('=', '')
+
+		$header = @{
+			'alg'      = 'RS256'
+			'typ'      = 'JWT'
+			'x5t#S256' = $base64Thumbprint
+		} | ConvertTo-Json
+		$base64Header = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($header))
+
+		$currentUnixTimestamp = [math]::Round(((Get-Date).ToUniversalTime() - ([datetime]'1970-01-01T00:00:00Z').ToUniversalTime()).TotalSeconds)
+
+		$payload = [Ordered]@{
+			'iss' = "$($actionContext.Configuration.AppId)"
+			'sub' = "$($actionContext.Configuration.AppId)"
+			'aud' = "https://login.microsoftonline.com/$($actionContext.Configuration.TenantID)/oauth2/token"
+			'exp' = ($currentUnixTimestamp + 3600)
+			'nbf' = ($currentUnixTimestamp - 300)
+			'iat' = $currentUnixTimestamp
+			'jti' = [Guid]::NewGuid().ToString()
+		} | ConvertTo-Json
+		$base64Payload = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($payload)).Replace('+', '-').Replace('/', '_').Replace('=', '')
+
+		$rsaPrivate = $Certificate.PrivateKey
+		$rsa = [System.Security.Cryptography.RSACryptoServiceProvider]::new()
+		$rsa.ImportParameters($rsaPrivate.ExportParameters($true))
+
+		$signatureInput = "$base64Header.$base64Payload"
+		$signature = $rsa.SignData([Text.Encoding]::UTF8.GetBytes($signatureInput), 'SHA256')
+		$base64Signature = [System.Convert]::ToBase64String($signature).Replace('+', '-').Replace('/', '_').Replace('=', '')
+
+		if (-not $Certificate.HasPrivateKey -or -not $Certificate.PrivateKey) {
+			throw 'The certificate does not have a private key.'
+		}
+
+		$jwtToken = "$($base64Header).$($base64Payload).$($base64Signature)"
+
+		$createEntraAccessTokenBody = @{
+			grant_type            = 'client_credentials'
+			client_id             = $actionContext.Configuration.AppId
+			client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+			client_assertion      = $jwtToken
+			resource              = 'https://graph.microsoft.com'
+		}
+
+		$createEntraAccessTokenSplatParams = @{
+			Uri         = "https://login.microsoftonline.com/$($actionContext.Configuration.TenantID)/oauth2/token"
+			Body        = $createEntraAccessTokenBody
+			Method      = 'POST'
+			ContentType = 'application/x-www-form-urlencoded'
+			Verbose     = $false
+			ErrorAction = 'Stop'
+		}
+
+		$createEntraAccessTokenResponse = Invoke-RestMethod @createEntraAccessTokenSplatParams
+		Write-Output $createEntraAccessTokenResponse.access_token
+	}
+	catch {
+		$PSCmdlet.ThrowTerminatingError($_)
+	}
+}
+
+function Get-MSEntraCertificate {
+	[CmdletBinding()]
+	param()
+	try {
+		$rawCertificate = [system.convert]::FromBase64String($actionContext.Configuration.AppCertificateBase64String)
+		$certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+			$rawCertificate,
+			$actionContext.Configuration.AppCertificatePassword,
+			[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
+		)
+		Write-Output $certificate
+	}
+	catch {
+		$PSCmdlet.ThrowTerminatingError($_)
+	}
+}
+#endregion functions
+
+try {
+	if ([string]::IsNullOrEmpty($actionContext.References.Account)) {
+		throw 'The account reference could not be found'
+	}
+
+	Write-Information 'Verifying if a Microsoft Entra account exists'
+    
+
+	$tapLifetimeInput = [string]$actionContext.Configuration.TemporaryAccesPassLifetime
+	$tapLifetime = 0
+	if (-not [int]::TryParse($tapLifetimeInput.Trim(), [ref]$tapLifetime) -or $tapLifetime -le 0) {
+		throw "TemporaryAccesPassLifetime [$tapLifetimeInput] is not a valid positive number."
+	}
+
+	$bodyTAP = @{
+		lifetimeInMinutes = $tapLifetime
+		isUsableOnce      = $true
+	}
+
+	$actionMessage = 'creating Microsoft Entra access token'
+	$certificate = Get-MSEntraCertificate
+	$entraToken = Get-MSEntraAccessToken -Certificate $certificate
+
+	$actionMessage = "verifying if the correlated account exists [$($actionContext.References.Account)]"
+	$correlatedAccount = $null
+	try {
+		$splatGetEntraUser = @{
+			Uri         = "https://graph.microsoft.com/v1.0/users/$($actionContext.References.Account)?`$select=id,accountEnabled"
+			Method      = 'GET'
+			Headers     = @{ 'Authorization' = "Bearer $entraToken" }
+			ErrorAction = 'Stop'
+		}
+		$correlatedAccount = Invoke-RestMethod @splatGetEntraUser
+	}
+	catch {
+		if ($_.Exception.Response.StatusCode -eq 404) {
+			$correlatedAccount = $null
+		}
+		else {
+			throw $_
+		}
+	}
+
+	if ($null -ne $correlatedAccount) {
+		$lifecycleProcess = 'EnableAccount'
+	}
+	else {
+		$lifecycleProcess = 'NotFound'
+	}
+
+	# Process
+	switch ($lifecycleProcess) {
+		'EnableAccount' {
+			$actionMessage = "setting Temporary Access Pass for account [$($actionContext.References.Account)]"
+			$splatSetTemporaryAccessPass = @{
+				Uri         = "https://graph.microsoft.com/v1.0/users/$($actionContext.References.Account)/authentication/temporaryAccessPassMethods"
+				Method      = 'POST'
+				Headers     = @{ 'Authorization' = "Bearer $entraToken" }
+				Body        = ($bodyTAP | ConvertTo-Json -Depth 10)
+				ContentType = 'application/json; charset=utf-8'
+				ErrorAction = 'Stop'
+			}
+
+			if (-not($actionContext.DryRun -eq $true)) {
+				Write-Information "Enabling Temporary Access Pass for account with accountReference: [$($actionContext.References.Account)]"
+				$setTemporaryAccessPassResponse = Invoke-RestMethod @splatSetTemporaryAccessPass
+
+				$startDateTimeUtc =	[datetime]$setTemporaryAccessPassResponse.startDateTime
+				$validUntilDateTime = $startDateTimeUtc.AddMinutes($tapLifetime).ToLocalTime()
+
+				$outputContext.Data.validUntil = $validUntilDateTime.ToString('dd-MM-yyyy HH:mm', [System.Globalization.CultureInfo]::GetCultureInfo('nl-NL'))
+				$outputContext.Data.temporaryAccessPass = $setTemporaryAccessPassResponse.temporaryAccessPass
+
+				$outputContext.Success = $true
+				$outputContext.AuditLogs.Add([PSCustomObject]@{
+						Message = "Successfully enabled Temporary Access Pass for accountReference [$($actionContext.References.Account)] with a validity of [$tapLifetime] minutes."
+						IsError = $false
+					})
+			}
+			else {
+				Write-Information "[DryRun] Enable Temporary Access Pass for account with accountReference: [$($actionContext.References.Account)], will be executed during enforcement"
+				$outputContext.Success = $true
+				$outputContext.AuditLogs.Add([PSCustomObject]@{
+						Message = "[DryRun] Would enable Temporary Access Pass for accountReference [$($actionContext.References.Account)] with a validity of [$tapLifetime] minutes."
+						IsError = $false
+					})
+			}
+
+			break
+		}
+
+		'NotFound' {
+			Write-Information "Microsoft Entra account: [$($actionContext.References.Account)] could not be found, indicating that it may have been deleted"
+			$outputContext.Success = $false
+			$outputContext.AuditLogs.Add([PSCustomObject]@{
+					Message = "Account with accountReference [$($actionContext.References.Account)] could not be found, indicating that it may have been deleted."
+					IsError = $true
+				})
+
+			break
+		}
+	}
+}
+catch {
+	$outputContext.Success = $false
+	$ex = $PSItem
+
+	if ($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException' -or
+		$ex.Exception.GetType().FullName -eq 'System.Net.WebException') {
+		$errorObj = Resolve-MS-Entra-ExoError -ErrorObject $ex
+		$auditMessage = "Failed to enable Temporary Access Pass for accountReference [$($actionContext.References.Account)] during [$actionMessage]. Error: $($errorObj.FriendlyMessage)"
+		Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+	}
+	else {
+		$auditMessage = "Failed to enable Temporary Access Pass for accountReference [$($actionContext.References.Account)] during [$actionMessage]. Error: $($ex.Exception.Message)"
+		Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+	}
+
+	$outputContext.AuditLogs.Add([PSCustomObject]@{
+			Message = $auditMessage
+			IsError = $true
+		})
+}

--- a/temporaryAccessPass/fieldMapping.json
+++ b/temporaryAccessPass/fieldMapping.json
@@ -1,0 +1,70 @@
+{
+  "Version": "v1",
+  "MappingFields": [
+    {
+      "Name": "id",
+      "Description": "[Required] The unique identifier for the user. Read-only.\nUsed as AccountReference.",
+      "Type": "Text",
+      "MappingActions": [
+        {
+          "MapForActions": [
+            "Create"
+          ],
+          "MappingMode": "None",
+          "Value": "null",
+          "UsedInNotifications": false,
+          "StoreInAccountData": true
+        }
+      ]
+    },
+    {
+      "Name": "employeeId",
+      "Description": "[Required] The employee identifier assigned to the user by the organization.\\nThe maximum length is 16 characters.\nUsed as Correlation Key.",
+      "Type": "Text",
+      "MappingActions": [
+        {
+          "MapForActions": [
+            "Create"
+          ],
+          "MappingMode": "Field",
+          "Value": "\"Person.ExternalId\"",
+          "UsedInNotifications": false,
+          "StoreInAccountData": true
+        }
+      ]
+    },
+    {
+      "Name": "temporaryAccessPass",
+      "Description": "",
+      "Type": "Text",
+      "MappingActions": [
+        {
+          "MapForActions": [
+            "Enable"
+          ],
+          "MappingMode": "None",
+          "Value": "\"\"",
+          "UsedInNotifications": true,
+          "StoreInAccountData": false
+        }
+      ]
+    },
+    {
+      "Name": "validUntil",
+      "Description": "",
+      "Type": "Text",
+      "MappingActions": [
+        {
+          "MapForActions": [
+            "Enable"
+          ],
+          "MappingMode": "None",
+          "Value": "\"\"",
+          "UsedInNotifications": true,
+          "StoreInAccountData": false
+        }
+      ]
+    }
+  ],
+  "UniqueFieldNames": []
+}

--- a/temporaryAccessPass/notification.mjml
+++ b/temporaryAccessPass/notification.mjml
@@ -1,0 +1,67 @@
+<mjml>
+  <mj-body background-color="#E7E7E7">
+    <mj-section>
+      <mj-column>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#4a8fca" padding-top="0" padding-bottom="0">
+      <mj-column width="25%">
+        <mj-image src="https://customer.helloid.com/appearance/companyicon" width="50px" height="50px">
+        </mj-image>
+      </mj-column>
+      <mj-column width="75%">
+        <mj-text font-family="Arial, Helvetica, sans-serif" font-size="14px" color="#FFFFFF" padding-top="25px" padding-bottom="25px">
+          Tijdelijke toegang voor {{person.primaryContract.company||"uw organisatie"}}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#FFFFFF">
+      <mj-column>
+        <mj-text font-family="Arial, Helvetica, sans-serif" font-size="14px" color="#111111">
+          Beste {{person.name.nickName||person.name.givenName||"medewerker"}},
+          <br/>
+          <br/>
+          Er is een Temporary Access Pass (TAP) voor je account aangemaakt.
+          <br/>
+          Gebruik deze code om in te loggen en je aanmeldmethode in te stellen.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#FFFFFF" border="1px solid #d9d9d9" padding-top="0" padding-bottom="0">
+      <mj-column width="40%">
+        <mj-text font-family="Arial, Helvetica, sans-serif" font-size="14px" color="#111111" font-weight="700">
+          Temporary Access Pass:
+          <br/>
+          Geldig tot:
+        </mj-text>
+      </mj-column>
+      <mj-column width="60%">
+        <mj-text font-family="Arial, Helvetica, sans-serif" font-size="14px" color="#111111">
+          {{ Data.temporaryAccessPass }}
+          <br/>
+          {{ Data.validUntil }}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#FFFFFF">
+      <mj-column>
+        <mj-text font-family="Arial, Helvetica, sans-serif" font-size="14px" color="#111111">
+          Belangrijk:
+          <br/>
+          - De TAP is eenmalig te gebruiken.
+          <br/>
+          - Deel de TAP niet met anderen.
+          <br/>
+          - Gebruik de TAP zo snel mogelijk.
+          <br/>
+          <br/>
+          Dit is een automatisch gegenereerd bericht.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>


### PR DESCRIPTION
## Summary
- add `temporaryAccessPass` module with configuration, field mapping and enable script
- add TAP outputs for notifications: `Data.temporaryAccessPass` and `Data.validUntil`
- add minimal MJML notification template for TAP
- add TAP documentation and rollout guidance

## Note
Because there is another PR that also touches changelog content, the changelog for this change is included in:
- `temporaryAccessPass/CHANGELOG.md`

## Validation
- markdown checks on updated TAP README
- no errors on `temporaryAccessPass/CHANGELOG.md`